### PR TITLE
Fix crash and preserve comments

### DIFF
--- a/transforms/require-with-props-to-named-import.js
+++ b/transforms/require-with-props-to-named-import.js
@@ -21,8 +21,15 @@ function transformer(file, api, options) {
     const j = api.jscodeshift;
     const logger = new Logger(file, options);
 
+    const root = j(file.source);
+
+    const getFirstNode = () => root.find(j.Program).get("body", 0).node;
+
+    // Save the comments attached to the first node
+    const firstNodeComments = getFirstNode().comments;
+
     // ------------------------------------------------------------------ SEARCH
-    const nodes = j(file.source)
+    const nodes = root
         .find(j.VariableDeclaration, {
             declarations: [
                 {
@@ -44,59 +51,60 @@ function transformer(file, api, options) {
     logger.log(`${nodes.length} nodes will be transformed`);
 
     // ----------------------------------------------------------------- REPLACE
-    return nodes
-        .replaceWith((path) => {
-            const rest = [];
-            const imports = [];
-            for (const declaration of path.node.declarations) {
-                // https://astexplorer.net/#/gist/49d222c86971cbe3e5744958989dc061/b0b5d0c31a6e74f63365c2ec1f195d3227c49621
-                // const a = require("a").a
-                const isRequireWithProp =
-                    declaration.init !== null &&
-                    declaration.init.type === "MemberExpression" &&
-                    declaration.init.object.type === "CallExpression" &&
-                    declaration.init.object.callee.name === "require" &&
-                    declaration.init.property !== undefined;
-                if (isRequireWithProp) {
-                    if (declaration.id.type === "Identifier") {
-                        const sourcePath = declaration.init.object.arguments.shift();
-                        if (declaration.init.object.arguments.length) {
-                            logger.error(
-                                `${logger.lines(declaration)} too many arguments.` + "Aborting transformation"
-                            );
-                            return file.source;
-                        }
-                        if (!j.Literal.check(sourcePath)) {
-                            logger.error(
-                                `${logger.lines(declaration)} bad argument.` +
-                                    "Expecting a string literal, got " +
-                                    j(sourcePath).toSource() +
-                                    "`. Aborting transformation"
-                            );
-                            return file.source;
-                        }
-                        if (declaration?.init?.property.type !== "Identifier") {
-                            logger.log("Unknown declaration", declaration);
-                            return file.source;
-                        }
-                        const specify = j.importSpecifier(declaration.init.property, declaration.id);
-                        imports.push(j.importDeclaration([specify], sourcePath));
-                    } else if (declaration.id.type === "ObjectPattern") {
-                        // named import
-                        // const { c } = require("mod").a
-                        logger.log("Does not support pattern", declaration);
+    nodes.replaceWith((path) => {
+        const rest = [];
+        const imports = [];
+        for (const declaration of path.node.declarations) {
+            // https://astexplorer.net/#/gist/49d222c86971cbe3e5744958989dc061/b0b5d0c31a6e74f63365c2ec1f195d3227c49621
+            // const a = require("a").a
+            const isRequireWithProp =
+                declaration.init !== null &&
+                declaration.init.type === "MemberExpression" &&
+                declaration.init.object.type === "CallExpression" &&
+                declaration.init.object.callee.name === "require" &&
+                declaration.init.property !== undefined;
+            if (isRequireWithProp) {
+                if (declaration.id.type === "Identifier") {
+                    const sourcePath = declaration.init.object.arguments.shift();
+                    if (declaration.init.object.arguments.length) {
+                        logger.error(`${logger.lines(declaration)} too many arguments.` + "Aborting transformation");
+                        return file.source;
                     }
-                } else {
-                    rest.push(declaration);
+                    if (!j.Literal.check(sourcePath)) {
+                        logger.error(
+                            `${logger.lines(declaration)} bad argument.` +
+                                "Expecting a string literal, got " +
+                                j(sourcePath).toSource() +
+                                "`. Aborting transformation"
+                        );
+                        return file.source;
+                    }
+                    if (declaration?.init?.property.type !== "Identifier") {
+                        logger.log("Unknown declaration", declaration);
+                        return file.source;
+                    }
+                    const specify = j.importSpecifier(declaration.init.property, declaration.id);
+                    imports.push(j.importDeclaration([specify], sourcePath));
+                } else if (declaration.id.type === "ObjectPattern") {
+                    // named import
+                    // const { c } = require("mod").a
+                    logger.log("Does not support pattern", declaration);
                 }
+            } else {
+                rest.push(declaration);
             }
-            if (rest.length > 0) {
-                logger.warn(`${logger.lines(path.node)} introduced leftover`);
-                return [...imports, j.variableDeclaration(path.node.kind, rest)];
-            }
-            return imports;
-        })
-        .toSource();
+        }
+        if (rest.length > 0) {
+            logger.warn(`${logger.lines(path.node)} introduced leftover`);
+            return [...imports, j.variableDeclaration(path.node.kind, rest)];
+        }
+        return imports;
+    });
+
+    // Restore comments
+    getFirstNode().comments = firstNodeComments;
+
+    return root.toSource();
 }
 
 export default transformer;


### PR DESCRIPTION
This PR ensures this codemod preserves leading comments (see https://github.com/facebook/jscodeshift/blob/main/recipes/retain-first-comment.md)

Additionally, a workaround is added for a crash resulting from a bug in `ast-types` (see https://github.com/benjamn/ast-types/issues/425#issuecomment-1007846129)