### PR TITLE
Fix bug with named exports

### DIFF
--- a/transforms/module-exports-to-named-export.js
+++ b/transforms/module-exports-to-named-export.js
@@ -63,7 +63,7 @@ function transformer(file, api, options) {
         // module.export.b = a
         // → export { a as b }
         if (id.type === "Identifier" && init.type === "Identifier") {
-            return j.exportNamedDeclaration(null, [j.exportSpecifier(init, id)]);
+            return j.exportNamedDeclaration(null, [j.exportSpecifier.from({ exported: init, local: id })]);
         }
         // https://babeljs.io/docs/en/babel-types#exportnameddeclaration
         const declaration = j.variableDeclaration("const", [j.variableDeclarator(id, init)]);

--- a/transforms/module-exports-to-named-export.js
+++ b/transforms/module-exports-to-named-export.js
@@ -63,7 +63,7 @@ function transformer(file, api, options) {
         // module.export.b = a
         // → export { a as b }
         if (id.type === "Identifier" && init.type === "Identifier") {
-            return j.exportNamedDeclaration(null, [j.exportSpecifier.from({ exported: init, local: id })]);
+            return j.exportNamedDeclaration(null, [j.exportSpecifier.from({ exported: id, local: init })]);
         }
         // https://babeljs.io/docs/en/babel-types#exportnameddeclaration
         const declaration = j.variableDeclaration("const", [j.variableDeclarator(id, init)]);


### PR DESCRIPTION
There is a bug where this code:

```js
const products = require('./data/products');
exports.products = products;
```

causes this error:

`Transformation error ("products" does not match field "name": Identifier | null of type ExportSpecifier)` 


This seems to fix it. 

References: 

1. https://github.com/homer0/cjs2esm/pull/15/files
2. https://github.com/benjamn/ast-types/issues/425#issuecomment-1007846129 
