### PR TITLE
Fix export as object expression conversion

### DIFF
--- a/transforms/__testfixtures__/module-exports-to-export-default/exports-as-object.input.js
+++ b/transforms/__testfixtures__/module-exports-to-export-default/exports-as-object.input.js
@@ -1,0 +1,2 @@
+const foo = 5;
+module.exports = { foo };

--- a/transforms/__testfixtures__/module-exports-to-export-default/exports-as-object.output.js
+++ b/transforms/__testfixtures__/module-exports-to-export-default/exports-as-object.output.js
@@ -1,0 +1,2 @@
+const foo = 5;
+export { foo };

--- a/transforms/__tests__/module-exports-to-export-default-test.js
+++ b/transforms/__tests__/module-exports-to-export-default-test.js
@@ -1,11 +1,5 @@
-import { defineTest } from "jscodeshift/dist/testUtils";
-
-const tests = ["basic-case", "multiple-exports"];
+import { defineTests } from "../__testutils__/defineTests";
 
 describe("module-exports-to-export-default", () => {
-    tests.forEach((test) => {
-        defineTest(__dirname, "module-exports-to-export-default", {
-            silent: true
-        }, `module-exports-to-export-default/${test}`);
-    });
+    defineTests(__dirname, "module-exports-to-export-default");
 });

--- a/transforms/__tests__/module-exports-to-named-export-test.js
+++ b/transforms/__tests__/module-exports-to-named-export-test.js
@@ -1,9 +1,5 @@
-import { defineTest } from "jscodeshift/dist/testUtils";
-
-const tests = ["basic-case-module-exports", "basic-case-exports", "exports-variable"];
+import { defineTests } from "../__testutils__/defineTests";
 
 describe("module-exports-to-named-export", () => {
-    tests.forEach((test) => {
-        defineTest(__dirname, "module-exports-to-named-export", null, `module-exports-to-named-export/${test}`);
-    });
+    defineTests(__dirname, "module-exports-to-named-export");
 });

--- a/transforms/__tests__/require-to-import-default-test.js
+++ b/transforms/__tests__/require-to-import-default-test.js
@@ -1,20 +1,5 @@
-import { defineTest } from "jscodeshift/dist/testUtils";
-
-const tests = [
-    "bad-argument",
-    "basic-case",
-    "chained-requires-with-rest",
-    "chained-requires",
-    "too-many-arguments",
-    "destructure-require",
-    "destructure-multiple-require",
-    "destructure-require-alias"
-];
+import { defineTests } from "../__testutils__/defineTests";
 
 describe("require-to-import-default", () => {
-    tests.forEach((test) => {
-        defineTest(__dirname, "require-to-import-default", {
-            silent: true
-        }, `require-to-import-default/${test}`);
-    });
+    defineTests(__dirname, "require-to-import-default");
 });

--- a/transforms/__tests__/require-with-props-to-named-import-test.js
+++ b/transforms/__tests__/require-with-props-to-named-import-test.js
@@ -1,9 +1,5 @@
-import { defineTest } from "jscodeshift/dist/testUtils";
-
-const tests = ["basic-case", "alias"];
+import { defineTests } from "../__testutils__/defineTests";
 
 describe("require-with-props-to-named-import", () => {
-    tests.forEach((test) => {
-        defineTest(__dirname, "require-with-props-to-named-import", null, `require-with-props-to-named-import/${test}`);
-    });
+    defineTests(__dirname, "require-with-props-to-named-import");
 });

--- a/transforms/__testutils__/defineTests.js
+++ b/transforms/__testutils__/defineTests.js
@@ -1,0 +1,16 @@
+import { defineTest } from "jscodeshift/dist/testUtils";
+import fs from "fs";
+import path from "path"
+
+export function defineTests(dirName, transformName) {
+    const inputFileSuffixRegex = /\.input\.js$/i;
+    const tests = fs.readdirSync(path.resolve(dirName, "../__testfixtures__", transformName))
+        .filter(fileName => inputFileSuffixRegex.test(fileName))
+        .map(fileName => fileName.replace(inputFileSuffixRegex, ''));
+
+    tests.forEach((test) => {
+            defineTest(dirName, transformName, {
+                silent: true
+            }, `${transformName}/${test}`);
+        });
+}

--- a/transforms/module-exports-to-export-default.js
+++ b/transforms/module-exports-to-export-default.js
@@ -46,6 +46,9 @@ function transformer(file, api, options) {
     // ----------------------------------------------------------------- REPLACE
     return nodes
         .replaceWith((path) => {
+            if (path.node.expression.right.type === 'ObjectExpression') {
+                return j.exportDeclaration(false, path.node.expression.right);
+            }
             return j.exportDefaultDeclaration(path.node.expression.right);
         })
         .toSource();


### PR DESCRIPTION
I tested this on a big project with mixed ts and js and I encountered some errors.
I had a cjs module doing `module.exports = { foo }` and the ts module importing it without errors using `import { foo } from './my-cjs-module'`.
After conversion the ts import wasn't working anymore, this is the reason for this PR.
I also took the time to improve the dev experience with unit tests by removing some manual/duplicate code.

Summary:
- `module.exports = { foo, bar }` should be exported as `export { foo, bar }`
- improved unit-tests dev-experience