### PR TITLE
Default export patch

### DIFF
--- a/transforms/__testfixtures__/module-exports-to-export-default/object-exports.input.js
+++ b/transforms/__testfixtures__/module-exports-to-export-default/object-exports.input.js
@@ -1,0 +1,9 @@
+const foo = () => {
+    return 'foo';
+}
+
+const bar = () => {
+    return 'bar';
+}
+
+module.exports = { foo, bar };

--- a/transforms/__testfixtures__/module-exports-to-export-default/object-exports.output.js
+++ b/transforms/__testfixtures__/module-exports-to-export-default/object-exports.output.js
@@ -1,0 +1,9 @@
+const foo = () => {
+    return 'foo';
+}
+
+const bar = () => {
+    return 'bar';
+}
+
+export { foo, bar };

--- a/transforms/module-exports-to-export-default.js
+++ b/transforms/module-exports-to-export-default.js
@@ -47,6 +47,19 @@ function transformer(file, api, options) {
     // ----------------------------------------------------------------- REPLACE
     return nodes
         .replaceWith((path) => {
+            if(path.node.expression.right.type === 'ObjectExpression') {
+                return j.exportNamedDeclaration(
+                    null,
+                    path.node.expression.right.properties.map((prop) => {
+
+                        return j.exportSpecifier.from({
+                            exported: prop.key,
+                            local:  prop.value,
+                        });
+                    })
+                );
+            }
+
             return j.exportDefaultDeclaration(path.node.expression.right);
         })
         .toSource();


### PR DESCRIPTION
Making this patch because webstorm and vscode can't determine identifiers when importing with destructuring
module.js:
```js
export default { foo };
```
any file:
```js
import { foo } from './module'; // cannot define identifier 'foo'
```